### PR TITLE
优化: 断点续传后不需要重新计算 MD5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # CHANGELOG
 
+## 1.0.5
+
+- 为上传的分块数据 [UploadPart] 添加了 `blockSize`, 用于表示分块大小。
+
+- 为 [BaiduUploadHelper] 添加了几个参数
+
+  - fileTotalSize: 文件总大小
+  - uploadSpeed: 上传速度
+  - getProgress: 上传进度
+
 ## 1.0.4
 
 - 修复了一处 `BaiduUploadHelper` 恢复进度的 bug

--- a/lib/src/core/pan.dart
+++ b/lib/src/core/pan.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:baidupan/src/util/pan_utils.dart';
 import 'package:http/http.dart' as http;
 
 import 'package:baidupan/baidupan.dart';

--- a/lib/src/core/upload.g.dart
+++ b/lib/src/core/upload.g.dart
@@ -131,21 +131,7 @@ class BaiduPanUploadManager with BaiduPanMixin {
     return PreCreate.fromJson(map);
   }
 
-  int _getBlockSize(int memberLevel) {
-    int blockSize;
-
-    switch (memberLevel) {
-      case 1:
-        blockSize = 16 * 1024 * 1024;
-        break;
-      case 2:
-        blockSize = 32 * 1024 * 1024;
-        break;
-      default:
-        blockSize = 4 * 1024 * 1024;
-    }
-    return blockSize;
-  }
+  int _getBlockSize(int memberLevel) => PanUtils.getBlockSize(memberLevel);
 
   Future<UploadPart> uploadSinglePart({
     required String remotePath,
@@ -206,7 +192,7 @@ class BaiduPanUploadManager with BaiduPanMixin {
     final body = await utf8.decodeStream(response.stream);
     final map = json.decode(body);
 
-    return UploadPart.fromJson(map);
+    return UploadPart.fromJson(map, uploadBytes.length);
   }
 
   /// 合并分片文件，并创建远端文件

--- a/lib/src/core/upload.g.dart
+++ b/lib/src/core/upload.g.dart
@@ -1,5 +1,7 @@
 part of 'pan.dart';
 
+typedef Md5Calculated = void Function(BaiduMd5 md5);
+
 /// 处理上传文件
 ///
 /// 具体的上传能力和限制请参考 [官网](https://pan.baidu.com/union/doc/3ksg0s9ye)
@@ -44,6 +46,7 @@ class BaiduPanUploadManager with BaiduPanMixin {
   /// [rtype] 为重命名策略
   /// [uploadid] 为上传的id, 这个是远端的上传id，理论上是用于后续的分片上传
   /// [memberLevel] 为用户的会员等级，这个等级决定了可以上传多大的文件和切片规则
+  /// [md5Calculated] 为md5计算完成后的回调，用于获取到md5值
   ///
   Future<PreCreate> preCreate({
     required String remotePath,
@@ -52,6 +55,7 @@ class BaiduPanUploadManager with BaiduPanMixin {
     required int memberLevel,
     String? uploadid,
     BaiduMd5? md5,
+    Md5Calculated? onMd5Calculated,
   }) async {
     final path = 'rest/2.0/xpan/file';
     final method = 'precreate';
@@ -112,6 +116,8 @@ class BaiduPanUploadManager with BaiduPanMixin {
 
     body['content-md5'] = baiduMd5.contentMd5;
     body['slice-md5'] = baiduMd5.sliceMd5;
+
+    onMd5Calculated?.call(baiduMd5);
 
     final now = DateTime.now().millisecondsSinceEpoch / 1000;
     body['local_ctime'] = now.toString();

--- a/lib/src/core/upload.g.dart
+++ b/lib/src/core/upload.g.dart
@@ -51,6 +51,9 @@ class BaiduPanUploadManager with BaiduPanMixin {
     UploadRenameRtype rtype = UploadRenameRtype.none,
     required int memberLevel,
     String? uploadid,
+    List<String>? blockMd5List,
+    String? contentMd5,
+    String? sliceMd5,
   }) async {
     final path = 'rest/2.0/xpan/file';
     final method = 'precreate';
@@ -99,17 +102,17 @@ class BaiduPanUploadManager with BaiduPanMixin {
       throw Exception('不支持的类型');
     }
 
-    final blockSize = _getBlockSize(memberLevel);
-
-    final blockMd5 = Md5Utils.getBlockList(
-      localPath,
-      blockSize,
+    final baiduMd5 = BaiduMd5(
+      filePath: localPath,
+      memberLevel: memberLevel,
     );
+
+    final blockMd5 = blockMd5List ?? baiduMd5.blockMd5List;
 
     body['block_list'] = json.encode(blockMd5);
 
-    body['content-md5'] = Md5Utils.getFileMd5(localPath);
-    body['slice-md5'] = Md5Utils.getFileSliceMd5(localPath, 256 * 1024);
+    body['content-md5'] = contentMd5 ?? baiduMd5.contentMd5;
+    body['slice-md5'] = sliceMd5 ?? baiduMd5.sliceMd5;
 
     final now = DateTime.now().millisecondsSinceEpoch / 1000;
     body['local_ctime'] = now.toString();

--- a/lib/src/core/upload.g.dart
+++ b/lib/src/core/upload.g.dart
@@ -51,9 +51,7 @@ class BaiduPanUploadManager with BaiduPanMixin {
     UploadRenameRtype rtype = UploadRenameRtype.none,
     required int memberLevel,
     String? uploadid,
-    List<String>? blockMd5List,
-    String? contentMd5,
-    String? sliceMd5,
+    BaiduMd5? md5,
   }) async {
     final path = 'rest/2.0/xpan/file';
     final method = 'precreate';
@@ -102,17 +100,18 @@ class BaiduPanUploadManager with BaiduPanMixin {
       throw Exception('不支持的类型');
     }
 
-    final baiduMd5 = BaiduMd5(
-      filePath: localPath,
-      memberLevel: memberLevel,
-    );
+    final baiduMd5 = md5 ??
+        BaiduMd5(
+          filePath: localPath,
+          memberLevel: memberLevel,
+        );
 
-    final blockMd5 = blockMd5List ?? baiduMd5.blockMd5List;
+    final blockMd5 = baiduMd5.blockMd5List;
 
     body['block_list'] = json.encode(blockMd5);
 
-    body['content-md5'] = contentMd5 ?? baiduMd5.contentMd5;
-    body['slice-md5'] = sliceMd5 ?? baiduMd5.sliceMd5;
+    body['content-md5'] = baiduMd5.contentMd5;
+    body['slice-md5'] = baiduMd5.sliceMd5;
 
     final now = DateTime.now().millisecondsSinceEpoch / 1000;
     body['local_ctime'] = now.toString();

--- a/lib/src/entity/upload.dart
+++ b/lib/src/entity/upload.dart
@@ -19,7 +19,8 @@ class PreCreate {
   });
 
   factory PreCreate.fromJson(Map json) {
-    final List<int> blockList = json['block_list'];
+    final _blockValue = json['block_list'] as List;
+    final blockList = _blockValue.whereType<int>().toList();
     return PreCreate(
       path: json['path'],
       returnType: json['return_type'],

--- a/lib/src/entity/upload.dart
+++ b/lib/src/entity/upload.dart
@@ -19,10 +19,11 @@ class PreCreate {
   });
 
   factory PreCreate.fromJson(Map json) {
+    final List<int> blockList = json['block_list'];
     return PreCreate(
       path: json['path'],
       returnType: json['return_type'],
-      blockList: json['block_list'].cast<int>(),
+      blockList: blockList,
       errno: json['errno'],
       requestId: json['request_id'],
       uploadId: json['uploadid'],

--- a/lib/src/entity/upload.dart
+++ b/lib/src/entity/upload.dart
@@ -34,16 +34,19 @@ class PreCreate {
 class UploadPart {
   final String md5;
   final int requestId;
+  final int blockSize;
 
   UploadPart({
     required this.md5,
     required this.requestId,
+    required this.blockSize,
   });
 
-  factory UploadPart.fromJson(Map json) {
+  factory UploadPart.fromJson(Map json, int fileSize) {
     return UploadPart(
       md5: json['md5'],
       requestId: json['request_id'],
+      blockSize: fileSize,
     );
   }
 }

--- a/lib/src/helper/baidu_upload_helper.dart
+++ b/lib/src/helper/baidu_upload_helper.dart
@@ -119,6 +119,7 @@ class BaiduUploadHelper with ILogger {
       'localPath': localPath,
       'remotePath': remotePath,
       'memberLevel': memberLevel,
+      'saveFileLength': fileTotalSize,
       'md5': _md5?.toMap(),
     };
   }

--- a/lib/src/helper/baidu_upload_helper.dart
+++ b/lib/src/helper/baidu_upload_helper.dart
@@ -216,7 +216,7 @@ class BaiduUploadHelper with ILogger {
 
       final uploadTimeMs = stopwatch.elapsedMilliseconds;
       uploadBytes += block.blockSize;
-      uploadSpeed = uploadBytes ~/ uploadTimeMs;
+      uploadSpeed = uploadBytes ~/ (uploadTimeMs / 1000);
 
       _blockMd5Map[blockIndex] = block.md5;
       uploadCount++;

--- a/lib/src/helper/baidu_upload_helper.dart
+++ b/lib/src/helper/baidu_upload_helper.dart
@@ -122,10 +122,6 @@ class BaiduUploadHelper with ILogger {
 
   /// 获取应该被保存的 map
   Map<String, dynamic> getSaveProgressMap() {
-    if (_uploadId == null) {
-      throw Exception('uploadId is null, please call startUpload() first');
-    }
-
     return {
       'uploadId': _uploadId,
       'localPath': localPath,

--- a/lib/src/helper/baidu_upload_helper.dart
+++ b/lib/src/helper/baidu_upload_helper.dart
@@ -201,8 +201,11 @@ class BaiduUploadHelper with ILogger {
     stopwatch.start();
     var uploadBytes = 0;
 
+    uploadCount = 0;
+
     for (final blockIndex in preCreate.blockList) {
       if (_blockMd5Map.containsKey(blockIndex)) {
+        uploadCount++;
         log('已经上传过的块：$blockIndex, 跳过');
         continue;
       }

--- a/lib/src/util/md5_utils.dart
+++ b/lib/src/util/md5_utils.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:baidupan/src/util/pan_utils.dart';
 import 'package:crypto/crypto.dart';
 
 class Md5Utils {
@@ -79,21 +80,7 @@ class BaiduMd5 {
     required this.memberLevel,
   });
 
-  int _getBlockSize(int memberLevel) {
-    int blockSize;
-
-    switch (memberLevel) {
-      case 1:
-        blockSize = 16 * 1024 * 1024;
-        break;
-      case 2:
-        blockSize = 32 * 1024 * 1024;
-        break;
-      default:
-        blockSize = 4 * 1024 * 1024;
-    }
-    return blockSize;
-  }
+  int _getBlockSize(int memberLevel) => PanUtils.getBlockSize(memberLevel);
 
   List<String> get blockMd5List {
     final blockSize = _getBlockSize(memberLevel);

--- a/lib/src/util/md5_utils.dart
+++ b/lib/src/util/md5_utils.dart
@@ -80,20 +80,6 @@ class BaiduMd5 {
     required this.memberLevel,
   });
 
-  List<String>? _blockMd5List;
-
-  List<String> get blockMd5List {
-    if (_blockMd5List != null) {
-      return _blockMd5List!;
-    }
-
-    final blockSize = PanUtils.getBlockSize(memberLevel);
-    return Md5Utils.getBlockList(
-      filePath,
-      blockSize,
-    );
-  }
-
   String? _contentMd5;
 
   String get contentMd5 {
@@ -106,6 +92,22 @@ class BaiduMd5 {
   String get sliceMd5 {
     _sliceMd5 ??= Md5Utils.getFileSliceMd5(filePath, 256 * 1024);
     return _sliceMd5!;
+  }
+
+  List<String>? _blockMd5List;
+
+  List<String> get blockMd5List {
+    if (_blockMd5List != null) {
+      return _blockMd5List!;
+    }
+
+    final blockSize = PanUtils.getBlockSize(memberLevel);
+    _blockMd5List ??= Md5Utils.getBlockList(
+      filePath,
+      blockSize,
+    );
+
+    return _blockMd5List!;
   }
 
   Map<String, dynamic> toMap() {

--- a/lib/src/util/md5_utils.dart
+++ b/lib/src/util/md5_utils.dart
@@ -80,19 +80,54 @@ class BaiduMd5 {
     required this.memberLevel,
   });
 
-  int _getBlockSize(int memberLevel) => PanUtils.getBlockSize(memberLevel);
+  List<String>? _blockMd5List;
 
   List<String> get blockMd5List {
-    final blockSize = _getBlockSize(memberLevel);
+    if (_blockMd5List != null) {
+      return _blockMd5List!;
+    }
+
+    final blockSize = PanUtils.getBlockSize(memberLevel);
     return Md5Utils.getBlockList(
       filePath,
       blockSize,
     );
   }
 
-  String get contentMd5 => Md5Utils.getFileMd5(filePath);
+  String? _contentMd5;
 
-  String get sliceMd5 => Md5Utils.getFileSliceMd5(filePath, 256 * 1024);
+  String get contentMd5 {
+    _contentMd5 ??= Md5Utils.getFileMd5(filePath);
+    return _contentMd5!;
+  }
+
+  String? _sliceMd5;
+
+  String get sliceMd5 {
+    _sliceMd5 ??= Md5Utils.getFileSliceMd5(filePath, 256 * 1024);
+    return _sliceMd5!;
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'filePath': filePath,
+      'memberLevel': memberLevel,
+      'blockMd5List': blockMd5List,
+      'contentMd5': contentMd5,
+      'sliceMd5': sliceMd5,
+    };
+  }
+
+  factory BaiduMd5.fromMap(Map<String, dynamic> map) {
+    final instance = BaiduMd5(
+      filePath: map['filePath'],
+      memberLevel: map['memberLevel'],
+    );
+    instance._blockMd5List = map['blockMd5List'];
+    instance._contentMd5 = map['contentMd5'];
+    instance._sliceMd5 = map['sliceMd5'];
+    return instance;
+  }
 }
 
 class _DigestSink extends Sink<Digest> {

--- a/lib/src/util/md5_utils.dart
+++ b/lib/src/util/md5_utils.dart
@@ -123,7 +123,8 @@ class BaiduMd5 {
       filePath: map['filePath'],
       memberLevel: map['memberLevel'],
     );
-    instance._blockMd5List = map['blockMd5List'];
+    instance._blockMd5List =
+        (map['blockMd5List'] as List).whereType<String>().toList();
     instance._contentMd5 = map['contentMd5'];
     instance._sliceMd5 = map['sliceMd5'];
     return instance;

--- a/lib/src/util/md5_utils.dart
+++ b/lib/src/util/md5_utils.dart
@@ -70,6 +70,44 @@ class Md5Utils {
   }
 }
 
+class BaiduMd5 {
+  final String filePath;
+  final int memberLevel;
+
+  BaiduMd5({
+    required this.filePath,
+    required this.memberLevel,
+  });
+
+  int _getBlockSize(int memberLevel) {
+    int blockSize;
+
+    switch (memberLevel) {
+      case 1:
+        blockSize = 16 * 1024 * 1024;
+        break;
+      case 2:
+        blockSize = 32 * 1024 * 1024;
+        break;
+      default:
+        blockSize = 4 * 1024 * 1024;
+    }
+    return blockSize;
+  }
+
+  List<String> get blockMd5List {
+    final blockSize = _getBlockSize(memberLevel);
+    return Md5Utils.getBlockList(
+      filePath,
+      blockSize,
+    );
+  }
+
+  String get contentMd5 => Md5Utils.getFileMd5(filePath);
+
+  String get sliceMd5 => Md5Utils.getFileSliceMd5(filePath, 256 * 1024);
+}
+
 class _DigestSink extends Sink<Digest> {
   /// The value added to the sink.
   ///

--- a/lib/src/util/pan_utils.dart
+++ b/lib/src/util/pan_utils.dart
@@ -1,0 +1,18 @@
+/// 一些百度网盘的方法
+class PanUtils {
+  static int getBlockSize(int memberLevel) {
+    int blockSize;
+
+    switch (memberLevel) {
+      case 1:
+        blockSize = 16 * 1024 * 1024;
+        break;
+      case 2:
+        blockSize = 32 * 1024 * 1024;
+        break;
+      default:
+        blockSize = 4 * 1024 * 1024;
+    }
+    return blockSize;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,344 +5,337 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "26.0.0"
+    version: "38.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "3.4.1"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.3.0"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.1"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      url: "https://pub.flutter-io.cn"
-    source: hosted
-    version: "0.3.5"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   crypto:
     dependency: "direct main"
     description:
       name: crypto
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.2"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   http:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.3"
+    version: "0.13.4"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.2.0"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.1"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.11.1"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.5.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.0"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "0.10.10"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.12"
+    version: "1.20.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.9"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.11"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.5.0"
+    version: "8.2.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.flutter-io.cn"
+      url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.12.0 <3.0.0"
+  dart: ">=2.16.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: baidupan
 description: For wrapper baidu netdisk api with dart, user can use the package to query, update ,upload or download for baidu netdisk.
-version: 1.0.4
+version: 1.0.5
 homepage: https://github.com/Caijinglong/baidupan
 
 environment:


### PR DESCRIPTION
- [x] 为上传方法添加 md5 的传入入口
- [x] 在上传工具类的进度中保存 md5 信息，以便于续传时不重新计算
- [x] 为上传帮助类添加了几个属性